### PR TITLE
retrieval secret from vault KV v2 fixed

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -20,6 +20,9 @@ DOCUMENTATION = """
     secret:
       description: query you are making.
       required: True
+    kv_version:
+      description: KV secrets engine version
+      default: 'v1'
     token:
       description: vault token.
       env:
@@ -131,6 +134,7 @@ class HashiVault:
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
         self.namespace = kwargs.get('namespace', None)
+        self.kv_version = kwargs.get('kv_version', 'v1')
         self.avail_auth_method = ['approle', 'userpass', 'ldap']
 
         # split secret arg, which has format 'secret/hello:value' into secret='secret/hello' and secret_field='value'
@@ -193,6 +197,10 @@ class HashiVault:
 
         if data is None:
             raise AnsibleError("The secret %s doesn't seem to exist for hashi_vault lookup" % self.secret)
+
+        # data structure is a bit different for KV version 2 - see Vault API docs
+        if self.kv_version == 'v2':
+            data = data['data']
 
         if self.secret_field == '':
             return data['data']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If one want to get single secret key from Vault KV version 2 hashi_vault plugin fails. Workaround is to get all keys in secret path at once and use Ansible to work with a dict of values like this: https://github.com/ansible/ansible/pull/41132#issuecomment-477394505

Quick fix would be to have patched local hashi_vault lookup plugin as presented in this commit.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
hashi_vault lookup plugin
